### PR TITLE
Fix compilation of tests

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -303,14 +303,14 @@ pub fn enter_keys<W: Clone + IsA<Object> + IsA<Widget> + WidgetExt>(widget: &W, 
 /// #[macro_use]
 /// extern crate gtk_test;
 ///
-/// use gtk::{Button, ContainerExt, WidgetExt, Window, WindowType};
+/// use gtk::{prelude::BuildableExtManual, Button, ContainerExt, WidgetExt, Window, WindowType};
 ///
 /// # fn main() {
 /// gtk::init().expect("GTK init failed");
 /// let but = Button::new();
 /// let w = Window::new(WindowType::Toplevel);
 ///
-/// but.set_name("Button");
+/// but.set_widget_name("Button");
 /// w.add(&but);
 ///
 /// gtk_test::find_child_by_name::<Button, Window>(&w, "Button").expect("failed to find child");
@@ -339,7 +339,7 @@ pub fn find_child_by_name<C: IsA<Widget>, W: Clone + IsA<Object> + IsA<Widget>>(
 /// let but = Button::new();
 /// let w = Window::new(WindowType::Toplevel);
 ///
-/// but.set_name("Button");
+/// but.set_widget_name("Button");
 /// w.add(&but);
 ///
 /// gtk_test::find_widget_by_name(&w, "Button").unwrap();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -36,7 +36,7 @@ macro_rules! assert_label {
 ///
 /// # fn main() {
 /// gtk::init().expect("GTK init failed");
-/// let label = Label::new("I'm a label!");
+/// let label = Label::new(Some("I'm a label!"));
 /// assert_text!(label, "I'm a label!");
 /// # }
 /// ```
@@ -86,14 +86,14 @@ macro_rules! assert_title {
 /// # fn main() {
 /// gtk::init().expect("GTK init failed");
 /// let button = Button::new();
-/// button.set_name("Omelette");
+/// button.set_widget_name("Omelette");
 /// assert_name!(button, "Omelette");
 /// # }
 /// ```
 #[macro_export]
 macro_rules! assert_name {
     ($widget:expr, $string:expr) => {
-        assert_eq!($widget.get_name().expect("get text"), $string.to_string());
+        assert_eq!($widget.get_widget_name().expect("get text"), $string.to_string());
     };
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -21,7 +21,7 @@ pub fn init_ui() -> (Window, Label, Button) {
 
     let window = Window::new(WindowType::Toplevel);
     let b = gtk::Box::new(Orientation::Vertical, 0);
-    let label = Label::new("Test");
+    let label = Label::new(Some("Test"));
     let but = Button::new();
 
     let l = label.clone();


### PR DESCRIPTION
Running `cargo test` fails compilation of a handful of tests. This commit fixes that.
It seems to me the reason why it got under the radar is because the CI here doesn't actually run the tests, only builds the library. This could albo be tackled.

Tested on:
rustc 1.43.0
Ubuntu 19.10 x64