### PR TITLE
Update stable compiler to 1.40 on Travis and fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 rust:
   - nightly
   - beta
-  - 1.31.0 # stable
+  - 1.40.0 # stable
 
 env:
   - GTK=3.14

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -303,14 +303,14 @@ pub fn enter_keys<W: Clone + IsA<Object> + IsA<Widget> + WidgetExt>(widget: &W, 
 /// #[macro_use]
 /// extern crate gtk_test;
 ///
-/// use gtk::{Button, ContainerExt, WidgetExt, Window, WindowType};
+/// use gtk::{prelude::BuildableExtManual, Button, ContainerExt, WidgetExt, Window, WindowType};
 ///
 /// # fn main() {
 /// gtk::init().expect("GTK init failed");
 /// let but = Button::new();
 /// let w = Window::new(WindowType::Toplevel);
 ///
-/// but.set_name("Button");
+/// but.set_widget_name("Button");
 /// w.add(&but);
 ///
 /// gtk_test::find_child_by_name::<Button, Window>(&w, "Button").expect("failed to find child");
@@ -339,7 +339,7 @@ pub fn find_child_by_name<C: IsA<Widget>, W: Clone + IsA<Object> + IsA<Widget>>(
 /// let but = Button::new();
 /// let w = Window::new(WindowType::Toplevel);
 ///
-/// but.set_name("Button");
+/// but.set_widget_name("Button");
 /// w.add(&but);
 ///
 /// gtk_test::find_widget_by_name(&w, "Button").unwrap();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -36,7 +36,7 @@ macro_rules! assert_label {
 ///
 /// # fn main() {
 /// gtk::init().expect("GTK init failed");
-/// let label = Label::new("I'm a label!");
+/// let label = Label::new(Some("I'm a label!"));
 /// assert_text!(label, "I'm a label!");
 /// # }
 /// ```
@@ -86,14 +86,14 @@ macro_rules! assert_title {
 /// # fn main() {
 /// gtk::init().expect("GTK init failed");
 /// let button = Button::new();
-/// button.set_name("Omelette");
+/// button.set_widget_name("Omelette");
 /// assert_name!(button, "Omelette");
 /// # }
 /// ```
 #[macro_export]
 macro_rules! assert_name {
     ($widget:expr, $string:expr) => {
-        assert_eq!($widget.get_name().expect("get text"), $string.to_string());
+        assert_eq!($widget.get_widget_name().expect("get text"), $string.to_string());
     };
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -21,7 +21,7 @@ pub fn init_ui() -> (Window, Label, Button) {
 
     let window = Window::new(WindowType::Toplevel);
     let b = gtk::Box::new(Orientation::Vertical, 0);
-    let label = Label::new("Test");
+    let label = Label::new(Some("Test"));
     let but = Button::new();
 
     let l = label.clone();


### PR DESCRIPTION
This fixes error on Travis CI:
```
error[E0658]: using the `?` macro Kleene operator for "at most one" repetition is unstable (see issue #48075)
```
See Rust 1.32 announcement for details - https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html