### PR TITLE
Update enigo to 0.0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
       - libxtst-dev
       - at-spi2-core
       - openbox
+      - libxdo-dev
 
 before_script:
   - openbox & # needs a window manager for the tests (to get focus to work)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ appveyor = { repository = "GuillaumeGomez/gtk-test", service = "github" }
 travis-ci = { repository = "gtk-rs/gtk-test" }
 
 [dependencies]
-enigo = "^0.0.11"
+enigo = "^0.0.14"
 gdk = { git = "https://github.com/gtk-rs/gdk" }
 glib = { git = "https://github.com/gtk-rs/glib" }
 gtk = { git = "https://github.com/gtk-rs/gtk" }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -348,10 +348,8 @@ pub fn find_child_by_name<C: IsA<Widget>, W: Clone + IsA<Object> + IsA<Widget>>(
 pub fn find_widget_by_name<W: Clone + IsA<Object> + IsA<Widget>>(parent: &W, name: &str) -> Option<Widget> {
     if let Ok(container) = parent.clone().dynamic_cast::<Container>() {
         for child in container.get_children() {
-            if let Some(string) = child.get_widget_name() {
-                if string == name {
-                    return Some(child);
-                }
+            if child.get_widget_name() == name {
+                return Some(child);
             }
             if let Some(widget) = find_widget_by_name(&child, name) {
                 return Some(widget);
@@ -360,10 +358,8 @@ pub fn find_widget_by_name<W: Clone + IsA<Object> + IsA<Widget>>(parent: &W, nam
     }
     else if let Ok(bin) = parent.clone().dynamic_cast::<Bin>() {
         if let Some(child) = bin.get_child() {
-            if let Some(string) = child.get_widget_name() {
-                if string == name {
-                    return Some(child);
-                }
+            if child.get_widget_name() == name {
+                return Some(child);
             }
             if let Some(widget) = find_widget_by_name(&child, name) {
                 return Some(widget);
@@ -596,7 +592,7 @@ fn gdk_key_to_enigo_key(key: Key) -> enigo::Key {
         key::space => Space,
         key::BackSpace => Backspace,
         key::Escape => Escape,
-        key::Super_L | key::Super_R => Super,
+        key::Super_L | key::Super_R => Meta,
         key::Control_L | key::Control_R => Control,
         key::Shift_L | key::Shift_R => Shift,
         key::Shift_Lock => CapsLock,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -43,7 +43,7 @@ macro_rules! assert_label {
 #[macro_export]
 macro_rules! assert_text {
     ($widget:expr, $string:expr) => {
-        assert_eq!($widget.get_text().expect("get text"), $string.to_string());
+        assert_eq!($widget.get_text(), $string.to_string());
     };
 }
 
@@ -93,7 +93,7 @@ macro_rules! assert_title {
 #[macro_export]
 macro_rules! assert_name {
     ($widget:expr, $string:expr) => {
-        assert_eq!($widget.get_widget_name().expect("get text"), $string.to_string());
+        assert_eq!($widget.get_widget_name(), $string.to_string());
     };
 }
 


### PR DESCRIPTION
gtk-test currently depends on an outdated version of `enigo`, which depends on outdated versions of `bitflags` and `winapi`. This in turn causes clippy to warn in my project about multiple versions of dependencies:
```
warning: multiple versions for dependency `bitflags`: 0.9.1, 1.2.1
  |
  = note: `-W clippy::multiple-crate-versions` implied by `-W clippy::cargo`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#multiple_crate_versions

warning: multiple versions for dependency `winapi`: 0.3.8, 0.2.8
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#multiple_crate_versions
```
This commit updates `enigo` to 0.0.14.

The exact chain of dependencies is as follows.

old:
```
enigo 0.0.11 -> core-graphics 0.8.2 -> bitflags 0.9.1 
enigo 0.0.11 -> winapi 0.2.8
```
new:
```
enigo 0.0.14 -> core-graphics 0.18.0 -> bitflags 1.0
enigo 0.0.14 -> winapi 0.3.8
```